### PR TITLE
fix: 把已废弃的随访单在表格中显示

### DIFF
--- a/src/views/customer/components/FollowUpRecords.vue
+++ b/src/views/customer/components/FollowUpRecords.vue
@@ -46,7 +46,11 @@
           <a @click="retransmission(text, scope)">重发</a> |
           <a @click="ViewFollowUpTable(text, scope)">查看随访表</a>
         </span>
-        <a v-else-if="(scope.level===null && diseaseId>0) || (scope.level===null && scope.diseases.length===1) " @click="startLevel(text, scope)">分级</a>
+        <span v-else-if="scope.level===null">
+          <span v-if="scope.destroy" @click="ViewFollowUpTable(text, scope)">已废弃</span>
+          <a v-else-if="diseaseId>0 || scope.diseases.length === 1" @click="startLevel(text, scope)">分级</a>
+          <a v-else @click="ViewFollowUpTable(text, scope)">查看随访表</a>
+        </span>
         <a v-else @click="ViewFollowUpTable(text, scope)">查看随访表</a>
       </span>
     </a-table>

--- a/src/views/customer/components/SeeFollowUpSheet.vue
+++ b/src/views/customer/components/SeeFollowUpSheet.vue
@@ -5,7 +5,7 @@
       @cancel="handleOnModalCancel"
       :title="`慢病随访单记录表${headerTips}`"
       :width="1100"
-      :footer="(followTableData.level==null&&followTableData.status=='success'&&followTableData.diseases.length===1) ? undefined : null"
+      :footer="(followTableData.level==null&&followTableData.status=='success'&&(diseaseId>0 || followTableData.diseases.length === 1)&&!followTableData.destroy) ? undefined : null"
     >
       <template #footer>
         <a-popconfirm


### PR DESCRIPTION
https://www.leangoo.com/kanban/board/go/4575449/2ee4b1d96ffea8b0
点击进入分级页面显示废除。所在把废除显示在了表格中，并灰色显示