### PR TITLE
fix: 修复随访单项目显示

### DIFF
--- a/src/views/customer/components/SeeFollowUpSheet.vue
+++ b/src/views/customer/components/SeeFollowUpSheet.vue
@@ -352,10 +352,11 @@ export default {
     // 获取指标项目名
     async getHealthIndex () {
       const res = await getHealthIndex()
+      const items = this.items.filter(item => { if (item.indexItem !== null) return true })
       if (res.status === 200) {
         this.projects = (res.data || []).filter(project => {
           for (var index of project.items) {
-            for (var i of this.items) {
+            for (var i of items) {
               if (i.indexItem.id === index.id) {
                 return true
               }


### PR DESCRIPTION
查看随访单时，有些指标是添加进去的，所以这些指标没有所属项目，应判断再处理